### PR TITLE
Sign up and login page adjustments + navigation from signup -> login made possible using hyperlink

### DIFF
--- a/MarketMinds/Views/LoginView.xaml
+++ b/MarketMinds/Views/LoginView.xaml
@@ -9,35 +9,103 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid>
-        <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" Padding="50" CornerRadius="12" BorderBrush="{ThemeResource SystemAccentColorDark1}" BorderThickness="2" Width="550" HorizontalAlignment="Center" VerticalAlignment="Center">
+    <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" 
+                Padding="50" 
+                CornerRadius="12" 
+                BorderBrush="{ThemeResource SystemAccentColorDark1}" 
+                BorderThickness="2" 
+                Width="550">
             <StackPanel Spacing="20">
-                <TextBlock Text="Login Page" FontSize="42" FontWeight="Bold" TextAlignment="Center" Foreground="{ThemeResource SystemAccentColorDark2}"/>
-                <TextBlock Text="Welcome to our MarketPlace!" FontSize="24" Margin="0,5" TextAlignment="Center" Foreground="{ThemeResource SystemAccentColor}"/>
-                <TextBlock Text="{Binding ErrorMessage}" FontSize="18" Foreground="{ThemeResource SystemErrorTextColor}" TextAlignment="Center"/>
-                <TextBlock Text="{Binding FailedAttemptsText}" FontSize="18" Foreground="{ThemeResource SystemErrorTextColor}" TextAlignment="Center"/>
-                <TextBox PlaceholderText="Enter your email" Text="{Binding Email, Mode=TwoWay}" Width="Auto" Height="45"/>
-                <PasswordBox PlaceholderText="Enter your password" Password="{Binding Password, Mode=TwoWay}" Width="Auto" Height="45"/>
+                <TextBlock Text="Login Page" 
+                           FontSize="42" 
+                           FontWeight="Bold" 
+                           TextAlignment="Center" 
+                           Foreground="{ThemeResource SystemAccentColorDark2}"/>
+                <TextBlock Text="Welcome back to MarketMinds!" 
+                           FontSize="24" 
+                           TextAlignment="Center" 
+                           Margin="0,5"
+                           Foreground="{ThemeResource SystemAccentColor}"/>
+                <TextBlock Text="{Binding ErrorMessage}" 
+                           FontSize="18" 
+                           Foreground="{ThemeResource SystemErrorTextColor}" 
+                           TextAlignment="Center"/>
+                <TextBlock Text="{Binding FailedAttemptsText}" 
+                           FontSize="18" 
+                           Foreground="{ThemeResource SystemErrorTextColor}" 
+                           TextAlignment="Center"/>
+                
+                <TextBox PlaceholderText="Enter your email" 
+                         Text="{Binding Email, Mode=TwoWay}" 
+                         Width="Auto" 
+                         Height="45" 
+                         Padding="8" 
+                         BorderThickness="0" 
+                         CornerRadius="8"/>
+                
+                <PasswordBox PlaceholderText="Enter your password" 
+                             Password="{Binding Password, Mode=TwoWay}" 
+                             Width="Auto" 
+                             Height="45" 
+                             Padding="8" 
+                             BorderThickness="0" 
+                             CornerRadius="8"/>
+                
                 <!-- Captcha -->
-                <TextBlock Text="Captcha Verification" FontSize="18" FontWeight="Bold"/>
-                        <TextBox Text="{Binding CaptchaText}" 
-                                Width="Auto" Height="60" Padding="10" 
-                BorderBrush="{ThemeResource SystemAccentColor}" BorderThickness="3" CornerRadius="8"
-                FontFamily="Lucida Handwriting" FontSize="24" FontStyle="Italic" 
-                FontWeight="Bold" TextAlignment="Center" 
-                Foreground="{ThemeResource SystemAccentColorDark2}" Background="{ThemeResource TextControlBackgroundDisabled}"
-                IsReadOnly="True" IsHitTestVisible="False"/>
+                <TextBlock Text="Captcha Verification" 
+                           FontSize="18" 
+                           FontWeight="Bold"/>
+                
+                <TextBox Text="{Binding CaptchaText}" 
+                         Width="Auto" 
+                         Height="60" 
+                         Padding="10" 
+                         BorderBrush="{ThemeResource SystemAccentColor}" 
+                         BorderThickness="3" 
+                         CornerRadius="8"
+                         FontFamily="Lucida Handwriting" 
+                         FontSize="24" 
+                         FontStyle="Italic" 
+                         FontWeight="Bold" 
+                         TextAlignment="Center" 
+                         Foreground="{ThemeResource SystemAccentColorDark2}" 
+                         Background="{ThemeResource TextControlBackgroundDisabled}"
+                         IsReadOnly="True" 
+                         IsHitTestVisible="False"/>
 
-                <TextBox PlaceholderText="Enter Captcha" Text="{Binding CaptchaEnteredCode, Mode=TwoWay}" Width="Auto" Height="45"/>
+                <TextBox PlaceholderText="Enter Captcha" 
+                         Text="{Binding CaptchaEnteredCode, Mode=TwoWay}" 
+                         Width="Auto" 
+                         Height="45" 
+                         Padding="8" 
+                         BorderThickness="0" 
+                         CornerRadius="8"/>
 
-                <Button Content="Login" Command="{Binding LoginCommand}" IsEnabled="{Binding IsLoginEnabled}" Width="200" Height="50" Background="{ThemeResource AccentButtonBackground}" Foreground="{ThemeResource AccentButtonForeground}"
+                <Button Content="Login" 
+                        Command="{Binding LoginCommand}" 
+                        IsEnabled="{Binding IsLoginEnabled}" 
+                        Width="200" 
+                        Height="50" 
+                        Background="{ThemeResource AccentButtonBackground}" 
+                        Foreground="{ThemeResource AccentButtonForeground}"
+                        CornerRadius="8"
+                        FontSize="18"
+                        FontWeight="Bold"
                         HorizontalAlignment="Center"/>
 
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                    <TextBlock Text="Don't have an account? " FontSize="14"/>
-                    <TextBlock x:Name="RegisterButtonTextBlock" Text="Register now" Foreground="{ThemeResource SystemAccentColor}" FontSize="14" FontWeight="Bold" PointerPressed="RegisterButtonTextBlock_PointerPressed" />
+                <StackPanel Orientation="Horizontal" 
+                            HorizontalAlignment="Center" 
+                            Spacing="5">
+                    <TextBlock Text="Don't have an account? " 
+                               FontSize="14"/>
+                    <TextBlock x:Name="RegisterButtonTextBlock" 
+                               Text="Register now" 
+                               Foreground="{ThemeResource SystemAccentColor}" 
+                               FontSize="14" 
+                               FontWeight="Bold" 
+                               PointerPressed="RegisterButtonTextBlock_PointerPressed"/>
                 </StackPanel>
-
             </StackPanel>
         </Border>
     </Grid>

--- a/MarketMinds/Views/SignUpPage.xaml
+++ b/MarketMinds/Views/SignUpPage.xaml
@@ -17,102 +17,72 @@
                 BorderThickness="2" 
                 Width="550">
 			<StackPanel Spacing="20">
-
 				<!-- Title -->
 				<TextBlock Text="Signup Page" 
-                           FontSize="36" 
+                           FontSize="42" 
                            FontWeight="Bold" 
                            TextAlignment="Center" 
                            Foreground="{ThemeResource SystemAccentColorDark2}"/>
 				<TextBlock Text="Join MarketMinds today!" 
-                           FontSize="20" 
+                           FontSize="24" 
                            TextAlignment="Center" 
+                           Margin="0,5"
                            Foreground="{ThemeResource SystemAccentColor}"/>
 				<TextBlock x:Name="ErrorMessage" 
                            Text="" 
-                           FontSize="16" 
+                           FontSize="18" 
                            Foreground="{ThemeResource SystemErrorTextColor}" 
                            TextAlignment="Center"/>
 
 				<!-- Username -->
-				<StackPanel>
-					<TextBlock Text="Username" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
-                               Foreground="{ThemeResource SystemAccentColorDark2}"/>
-					<TextBox Text="{Binding Username, Mode=TwoWay}" 
-                             Width="Auto" 
-                             Height="40" 
-                             Padding="8" 
-                             BorderBrush="{ThemeResource SystemAccentColor}" 
-                             BorderThickness="2" 
-                             CornerRadius="8"/>
-				</StackPanel>
+				<TextBox Text="{Binding Username, Mode=TwoWay}" 
+                         PlaceholderText="Enter your username"
+                         Width="Auto" 
+                         Height="45" 
+                         Padding="8" 
+                         BorderThickness="0" 
+                         CornerRadius="8"/>
 
 				<!-- Email -->
-				<StackPanel>
-					<TextBlock Text="Email" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
-                               Foreground="{ThemeResource SystemAccentColorDark2}"/>
-					<TextBox Text="{Binding Email, Mode=TwoWay}" 
-                             Width="Auto" 
-                             Height="40" 
-                             Padding="8" 
-                             BorderBrush="{ThemeResource SystemAccentColor}" 
-                             BorderThickness="2" 
-                             CornerRadius="8"/>
-				</StackPanel>
+				<TextBox Text="{Binding Email, Mode=TwoWay}" 
+                         PlaceholderText="Enter your email"
+                         Width="Auto" 
+                         Height="45" 
+                         Padding="8" 
+                         BorderThickness="0" 
+                         CornerRadius="8"/>
 
 				<!-- Phone Number -->
-				<StackPanel>
-					<TextBlock Text="Phone Number" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
-                               Foreground="{ThemeResource SystemAccentColorDark2}"/>
-					<TextBox Text="{Binding PhoneNumber, Mode=TwoWay}" 
-                             Width="Auto" 
-                             Height="40" 
-                             Padding="8" 
-                             BorderBrush="{ThemeResource SystemAccentColor}" 
-                             BorderThickness="2" 
-                             CornerRadius="8"/>
-				</StackPanel>
+				<TextBox Text="{Binding PhoneNumber, Mode=TwoWay}" 
+                         PlaceholderText="Enter your phone number"
+                         Width="Auto" 
+                         Height="45" 
+                         Padding="8" 
+                         BorderThickness="0" 
+                         CornerRadius="8"/>
 
 				<!-- Password -->
-				<StackPanel>
-					<TextBlock Text="Password" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
-                               Foreground="{ThemeResource SystemAccentColorDark2}"/>
-					<PasswordBox Password="{Binding Password, Mode=TwoWay}" 
-                                 Width="Auto" 
-                                 Height="40" 
-                                 Padding="8" 
-                                 BorderBrush="{ThemeResource SystemAccentColor}" 
-                                 BorderThickness="2" 
-                                 CornerRadius="8"/>
-				</StackPanel>
+				<PasswordBox Password="{Binding Password, Mode=TwoWay}" 
+                             PlaceholderText="Enter your password"
+                             Width="Auto" 
+                             Height="45" 
+                             Padding="8" 
+                             BorderThickness="0" 
+                             CornerRadius="8"/>
 
 				<!-- Account Type -->
-				<StackPanel>
-					<TextBlock Text="Account Type" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
-                               Foreground="{ThemeResource SystemAccentColorDark2}"/>
-                    <ComboBox SelectedValue="{Binding Role, Mode=TwoWay}" 
-                              SelectedValuePath="Tag" 
-                              SelectedIndex="0" 
-                              Width="Auto" 
-                              Height="40" 
-                              Padding="8" 
-                              BorderBrush="{ThemeResource SystemAccentColor}" 
-                              BorderThickness="2" 
-                              CornerRadius="8">
-						<ComboBoxItem Content="Buyer" Tag="2"/>
-						<ComboBoxItem Content="Seller" Tag="3"/>
-					</ComboBox>
-				</StackPanel>
+				<ComboBox SelectedValue="{Binding Role, Mode=TwoWay}" 
+                          SelectedValuePath="Tag" 
+                          SelectedIndex="-1" 
+                          PlaceholderText="Select account type"
+                          Width="Auto" 
+                          Height="45" 
+                          Padding="8" 
+                          BorderThickness="0" 
+                          CornerRadius="8">
+					<ComboBoxItem Content="Buyer" Tag="2"/>
+					<ComboBoxItem Content="Seller" Tag="3"/>
+				</ComboBox>
 
 				<!-- Signup Button -->
 				<Button Content="Sign Up"
@@ -125,6 +95,17 @@
                         FontWeight="Bold"
                         Command="{Binding SignupCommand}"
                         HorizontalAlignment="Center"/>
+                
+                <!-- Login Link -->
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="5">
+                    <TextBlock Text="Already have an account? " FontSize="14"/>
+                    <TextBlock x:Name="LoginButtonTextBlock" 
+                               Text="Login now" 
+                               Foreground="{ThemeResource SystemAccentColor}" 
+                               FontSize="14" 
+                               FontWeight="Bold" 
+                               PointerPressed="LoginButtonTextBlock_PointerPressed" />
+                </StackPanel>
 			</StackPanel>
 		</Border>
 	</Grid>

--- a/MarketMinds/Views/SignUpPage.xaml.cs
+++ b/MarketMinds/Views/SignUpPage.xaml.cs
@@ -6,6 +6,7 @@ namespace MarketMinds.Views
 {
     using MarketMinds.ViewModels;
     using Microsoft.UI.Xaml.Controls;
+    using Microsoft.UI.Xaml.Input;
     using Microsoft.UI.Xaml.Navigation;
 
     /// <summary>
@@ -32,6 +33,19 @@ namespace MarketMinds.Views
             if (e.Parameter is ISignUpViewModel signUpViewModel)
             {
                 this.DataContext = signUpViewModel;
+            }
+        }
+
+        /// <summary>
+        /// Event handler for the login link.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void LoginButtonTextBlock_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            if (this.DataContext is ISignUpViewModel viewModel)
+            {
+                viewModel.NavigateToLogin?.Invoke();
             }
         }
     }


### PR DESCRIPTION
sign up page redo, adjusted styling for both login and sign up to feel more natural and look the same, added a way to navigate back to the login page through a hyperlink in the bottom of the sign up page, similar to the login page